### PR TITLE
Added loop to calculate doublets per sample

### DIFF
--- a/1-sample_QC/221015_basic_QC_and_scrublet_CaiY2022.ipynb
+++ b/1-sample_QC/221015_basic_QC_and_scrublet_CaiY2022.ipynb
@@ -1213,9 +1213,15 @@
     }
    ],
    "source": [
-    "scrub = scr.Scrublet(sample_object.X)\n",
-    "sample_object.obs['doublet_scores'], sample_object.obs['predicted_doublets'] = scrub.scrub_doublets()\n",
-    "scrub.plot_histogram()\n",
+    "holder = np.zeros((sample_object.shape[0],))\n",
+    "for smp in np.unique(sample_object.obs['sample']):\n",
+    "    if smp == []:\n",
+    "        continue\n",
+    "    adata_smp = sample_object[sample_object.obs['sample'] == smp]\n",
+    "    scrub = scr.Scrublet(adata_smp.X)\n",
+    "    adata_smp.obs['doublet_scores'], adata_smp.obs['predicted_doublets'] = scrub.scrub_doublets()\n",
+    "    holder[sample_object.obs['sample'] == smp] = adata_smp.obs['predicted_doublets']\n",
+    "sample_object.obs['predicted_doublets'] = holder\n",
     "\n",
     "sum(sample_object.obs['predicted_doublets'])"
    ]
@@ -1358,7 +1364,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.7"
   },
   "vscode": {
    "interpreter": {

--- a/1-sample_QC/221102_basic_QC_and_scrublet_Nathan2021.ipynb
+++ b/1-sample_QC/221102_basic_QC_and_scrublet_Nathan2021.ipynb
@@ -7,8 +7,8 @@
     "### Run basic `scanpy` QC and doublet detection with `scrublet` for **PBMC Tuberculosis** _Nathan et al 2021_\n",
     "\n",
     "- **Developed by**: Carlos Talavera-López PhD\n",
-    "- **Computational Health Centre - Helmholtz Munich**\n",
-    "- v221101"
+    "- ** Institute of Computational Biology - Computational Health Centre - Helmholtz Munich**\n",
+    "- v221123"
    ]
   },
   {
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata = sc.read_h5ad('/home/cartalop/data/single_cell/lung/tb/individual_studies/nathan2021/Lung_TB_T_Cells_GEX_raw.h5ad')\n",
+    "adata = sc.read_h5ad('/home/cartalop/data/carlos/single_cell/TB/Nathan2021/Lung_TB_T_Cells_CITESEQ_RNA.h5ad')\n",
     "adata"
    ]
   },
@@ -73,6 +73,24 @@
    "outputs": [],
    "source": [
     "adata.obs['donor'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.obs['sample'] = adata.obs['donor'].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.obs['sample'].value_counts()"
    ]
   },
   {
@@ -399,9 +417,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scrub = scr.Scrublet(sample_object.X)\n",
-    "sample_object.obs['doublet_scores'], sample_object.obs['predicted_doublets'] = scrub.scrub_doublets()\n",
-    "scrub.plot_histogram()\n",
+    "holder = np.zeros((sample_object.shape[0],))\n",
+    "for smp in np.unique(sample_object.obs['sample']):\n",
+    "    if smp == []:\n",
+    "        continue\n",
+    "    adata_smp = sample_object[sample_object.obs['sample'] == smp]\n",
+    "    scrub = scr.Scrublet(adata_smp.X)\n",
+    "    adata_smp.obs['doublet_scores'], adata_smp.obs['predicted_doublets'] = scrub.scrub_doublets()\n",
+    "    holder[sample_object.obs['sample'] == smp] = adata_smp.obs['predicted_doublets']\n",
+    "sample_object.obs['predicted_doublets'] = holder\n",
     "\n",
     "sum(sample_object.obs['predicted_doublets'])"
    ]
@@ -487,7 +511,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.7"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
The current notebooks calculate doublet scores on the whole object being run, which is not ideal. 

Doublet detection works best when calculated on a per-sample basis because it captures the library prep effect and makes the probability of a cell being a doublet more reliable. 

I did the following change in the code:

```
holder = np.zeros((sample_object.shape[0],))
for smp in np.unique(sample_object.obs['sample']):
    if smp == []:
        continue
    adata_smp = sample_object[sample_object.obs['sample'] == smp]
    scrub = scr.Scrublet(adata_smp.X)
    adata_smp.obs['doublet_scores'], adata_smp.obs['predicted_doublets'] = scrub.scrub_doublets()
    holder[sample_object.obs['sample'] == smp] = adata_smp.obs['predicted_doublets']
sample_object.obs['predicted_doublets'] = holder

sum(sample_object.obs['predicted_doublets'])
sample_object
```
